### PR TITLE
Bump gradle from 4.2.0-beta05 to 7.1.0-alpha06

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.0-beta05'
+        classpath 'com.android.tools.build:gradle:7.1.0-alpha06'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.3.2"
         classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_version"


### PR DESCRIPTION
Bumps gradle from 4.2.0-beta05 to 7.1.0-alpha06.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>